### PR TITLE
Changed Deployer link to Github repo

### DIFF
--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -91,4 +91,4 @@ PHP.
 [Jenkins]: http://jenkins-ci.org/
 [PHPCI]: http://www.phptesting.org/
 [Teamcity]: http://www.jetbrains.com/teamcity/
-[Deployer]: http://deployer.org/
+[Deployer]: https://github.com/deployphp/deployer


### PR DESCRIPTION
Because it seems that deployer.org it is down, maybe it is better to link to their Github repository instead.